### PR TITLE
Added WiFi Clover Device Patch

### DIFF
--- a/CLOVER/config.plist
+++ b/CLOVER/config.plist
@@ -404,6 +404,11 @@
 		</dict>
 		<key>Properties</key>
 		<dict>
+            <key>PciRoot(0x0)/Pci(0x1c,0x0)/Pci(0x0)</key>
+			<dict>
+				<key>pci-aspm-default</key>
+				<integer>0</integer>
+			</dict>
 			<key>PciRoot(0)/Pci(0x1f,3)</key>
 			<dict>
 				<key>Comment-layout-id</key>


### PR DESCRIPTION
Hi, not sure if you accept patches but I thought I would offer.

I needed this patch in order to get WiFi working. I got it from here https://www.tonymacx86.com/threads/the-solution-dell-dw1820a-broadcom-bcm94350zae-macos-15.288026/

I am not an expert by any means but I guess this card does not play well with active state power management. There is a chance this card could now be drawing more power because Mac won't shut it down but at least it is working now.

Thanks for your config by the way, saved me a ton of time and stress.